### PR TITLE
pfnmap DMA mapping race test, new Makefile, mmap align fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.o
+vfio-pci-device-dma-map
+vfio-pci-huge-fault-race
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 CFLAGS = -g -Wall
 
-TESTS = vfio-pci-device-dma-map
+TESTS = vfio-pci-device-dma-map vfio-pci-huge-fault-race
 
 vfio-pci-device-dma-map: vfio-pci-device-dma-map.o utils.o
+	$(CC) -o $@ $^
+
+vfio-pci-huge-fault-race: vfio-pci-huge-fault-race.o utils.o
 	$(CC) -o $@ $^
 
 all: $(TESTS)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-CFLAGS = -g -Wall
+CFLAGS := -g -Wall
 
-TESTS = vfio-pci-device-dma-map vfio-pci-huge-fault-race
+TESTS := vfio-pci-device-dma-map vfio-pci-huge-fault-race
+
+.DEFAULT_GOAL := all
 
 vfio-pci-device-dma-map: vfio-pci-device-dma-map.o utils.o
 	$(CC) -o $@ $^
@@ -8,7 +10,9 @@ vfio-pci-device-dma-map: vfio-pci-device-dma-map.o utils.o
 vfio-pci-huge-fault-race: vfio-pci-huge-fault-race.o utils.o
 	$(CC) -o $@ $^
 
+.PHONY: all
 all: $(TESTS)
 
+.PHONY: clean
 clean:
-	rm -f  $(TESTS) *.o
+	rm -f $(TESTS) *.o

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,26 @@
-CFLAGS := -g -Wall
+CFLAGS = -g -Wall
+SHARED_SRCS = utils.c
+HEADERS = utils.h
+TEST_SRCS = vfio-pci-device-dma-map.c vfio-pci-huge-fault-race.c
 
-TESTS := vfio-pci-device-dma-map vfio-pci-huge-fault-race
+SHARED_OBJS = $(SHARED_SRCS:.c=.o)
+TEST_BINS = $(TEST_SRCS:.c=)
+ARCHIVE_NAME = vfio-tests
 
-.DEFAULT_GOAL := all
+.PHONY: all clean archive
 
-vfio-pci-device-dma-map: vfio-pci-device-dma-map.o utils.o
-	$(CC) -o $@ $^
+all: $(TEST_BINS)
 
-vfio-pci-huge-fault-race: vfio-pci-huge-fault-race.o utils.o
-	$(CC) -o $@ $^
+$(TEST_BINS): %: %.o $(SHARED_OBJS)
+	$(CC) $(CFLAGS) -o $@ $^
 
-.PHONY: all
-all: $(TESTS)
+%.o: %.c $(HEADERS) Makefile
+	$(CC) $(CFLAGS) -c $< -o $@
 
-.PHONY: clean
 clean:
-	rm -f $(TESTS) *.o
+	rm -f $(SHARED_OBJS) $(TEST_SRCS:.c=.o) $(TEST_BINS) *.o $(ARCHIVE_NAME).tar.gz
+
+archive:
+	tar -czvf $(ARCHIVE_NAME).tar.gz Makefile $(SHARED_SRCS) $(TEST_SRCS) $(HEADERS)
+
+.PRECIOUS: $(TEST_BINS)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,15 @@ TEST_SRCS = vfio-pci-device-dma-map.c vfio-pci-huge-fault-race.c
 
 SHARED_OBJS = $(SHARED_SRCS:.c=.o)
 TEST_BINS = $(TEST_SRCS:.c=)
-ARCHIVE_NAME = vfio-tests
+ARCHIVE_BASE_NAME = vfio-tests
+GIT_SHA := $(shell git rev-parse --short HEAD 2>/dev/null)
+GIT_DIRTY := $(shell git diff --quiet || echo "-dirty" 2>/dev/null)
+ifeq ($(GIT_SHA),)
+  GIT_VERSION = nogit
+else
+  GIT_VERSION = $(GIT_SHA)$(GIT_DIRTY)
+endif
+ARCHIVE_NAME = $(ARCHIVE_BASE_NAME)-$(GIT_VERSION)
 
 .PHONY: all clean archive
 
@@ -18,7 +26,7 @@ $(TEST_BINS): %: %.o $(SHARED_OBJS)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -f $(SHARED_OBJS) $(TEST_SRCS:.c=.o) $(TEST_BINS) *.o $(ARCHIVE_NAME).tar.gz
+	rm -f $(SHARED_OBJS) $(TEST_SRCS:.c=.o) $(TEST_BINS) $(ARCHIVE_BASE_NAME)*.tar.gz
 
 archive:
 	tar -czvf $(ARCHIVE_NAME).tar.gz Makefile $(SHARED_SRCS) $(TEST_SRCS) $(HEADERS)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SHARED_OBJS = $(SHARED_SRCS:.c=.o)
 TEST_BINS = $(TEST_SRCS:.c=)
 ARCHIVE_BASE_NAME = vfio-tests
 GIT_SHA := $(shell git rev-parse --short HEAD 2>/dev/null)
-GIT_DIRTY := $(shell git diff --quiet || echo "-dirty" 2>/dev/null)
+GIT_DIRTY := $(shell git diff --quiet 2>/dev/null || echo "-dirty")
 ifeq ($(GIT_SHA),)
   GIT_VERSION = nogit
 else

--- a/utils.c
+++ b/utils.c
@@ -204,6 +204,7 @@ void *mmap_align(void *addr, size_t length, int prot, int flags,
 {
 	void *addr_align;
 	void *addr_base;
+	void *map;
 
 	addr_base = mmap(NULL, length + align, PROT_NONE,
 			 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
@@ -215,5 +216,8 @@ void *mmap_align(void *addr, size_t length, int prot, int flags,
 	munmap(addr_base, addr_align - addr_base);
 	munmap(addr_align + length, align - (addr_align - addr_base));
 
-	return mmap(addr_align, length, prot, flags | MAP_FIXED, fd, offset);
+	map = mmap(addr_align, length, prot, flags | MAP_FIXED, fd, offset);
+	if (map != MAP_FAILED)
+		madvise(map, length, MADV_HUGEPAGE);
+	return map;
 }

--- a/utils.c
+++ b/utils.c
@@ -215,5 +215,5 @@ void *mmap_align(void *addr, size_t length, int prot, int flags,
 	munmap(addr_base, addr_align - addr_base);
 	munmap(addr_align + length, align - (addr_align - addr_base));
 
-	return mmap(addr_align, length, prot, flags, fd, offset);
+	return mmap(addr_align, length, prot, flags | MAP_FIXED, fd, offset);
 }

--- a/vfio-pci-huge-fault-race.c
+++ b/vfio-pci-huge-fault-race.c
@@ -61,8 +61,6 @@ static void do_race(int device, struct vfio_region_info *region, size_t pagesz)
 			return;
 		}
 
-		madvise(map, pagesz, MADV_HUGEPAGE);
-
 		go = 0;
 		pthread_create(&thread1, NULL, thread_func, map + pagesz - getpagesize());
 		pthread_create(&thread2, NULL, thread_func, map);

--- a/vfio-pci-huge-fault-race.c
+++ b/vfio-pci-huge-fault-race.c
@@ -1,0 +1,151 @@
+/*
+ * VFIO test suite
+ *
+ * Copyright (C) 2012-2025, Red Hat Inc.
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2.  See
+ * the COPYING file in the top-level directory.
+ */
+
+#include <errno.h>
+#include <libgen.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/vfs.h>
+#include <time.h>
+#include <pthread.h>
+
+#include <linux/ioctl.h>
+#include <linux/vfio.h>
+
+#include "utils.h"
+
+void usage(char *name)
+{
+	printf("usage: %s <ssss:bb:dd.f>\n", name);
+}
+
+static int go;
+
+static void *thread_func(void *map)
+{
+	volatile unsigned long *val = map;
+
+	do {} while (!go);
+
+	(void)*val;
+	return NULL;
+}
+
+static void do_race(int device, struct vfio_region_info *region, size_t pagesz)
+{
+	int i;
+
+	for (i = 0; i < 100000;) {
+		pthread_t thread1, thread2;
+		void *map;
+		
+		map = mmap_align(NULL, pagesz, PROT_READ, MAP_SHARED,
+						 device, (off_t)region->offset, pagesz);
+		if (map == MAP_FAILED) {
+			printf("mmap failed: %s\n", strerror(errno));
+			return;
+		}
+
+		madvise(map, pagesz, MADV_HUGEPAGE);
+
+		go = 0;
+		pthread_create(&thread1, NULL, thread_func, map + pagesz - getpagesize());
+		pthread_create(&thread2, NULL, thread_func, map);
+		go = 1;
+		pthread_join(thread1, NULL);
+		pthread_join(thread2, NULL);
+
+		munmap(map, pagesz);
+		if (!(++i % 10000)) {
+			printf(".");
+			fflush(stdout);
+		}
+	}
+	printf(" [DONE]\n");
+}
+
+int main(int argc, char **argv)
+{
+	const char *devname;
+	int container, device;
+	int region, ret;
+	struct vfio_device_info device_info = {	.argsz = sizeof(device_info) };
+	struct vfio_region_info region_info = { .argsz = sizeof(region_info) };
+	size_t *pgsize, pgsizes[] = {
+		2ul * 1024 * 1024,
+		/* Only PMD generates this issue */
+		1ul * 1024ul * 1024 * 1024,
+		0
+	};
+
+	if (argc < 2) {
+		usage(argv[0]);
+		return -EINVAL;
+	}
+
+	devname = argv[1];
+
+	if (vfio_device_attach(devname, &container, &device))
+		return -1;
+
+	ret = ioctl(device, VFIO_DEVICE_GET_INFO, &device_info);
+	if (ret) {
+		printf("VFIO_DEVICE_GET_INFO failed: %d (%s)\n",
+		       ret, strerror(errno));
+		return errno;
+	}
+
+	if (!(device_info.flags & VFIO_DEVICE_FLAGS_PCI) ||
+		device_info.num_regions < VFIO_PCI_BAR5_REGION_INDEX) {
+		printf("Invalid vfio-pci device\n");
+		return -ENODEV;
+	}
+
+	printf("Running tests, if progress dots stop or system generates errors, the test has failed\n");
+
+	for (pgsize = &pgsizes[0]; *pgsize; pgsize++) {
+		for (region = 0; region < VFIO_PCI_ROM_REGION_INDEX; region++) {
+			region_info.index = region;
+			ret = ioctl(device, VFIO_DEVICE_GET_REGION_INFO, &region_info);
+			if (ret) {
+				printf("VFIO_DEVICE_GET_REGION_INFO failed for region %d: %d (%s)\n",
+					   region_info.index, ret, strerror(errno));
+				return errno;
+			}
+
+			if (!(region_info.flags & VFIO_REGION_INFO_FLAG_MMAP) ||
+				region_info.size < *pgsize)
+				continue;
+	
+			printf("Using BAR%d (size %ldMB) for %ldMB page size test\n", region,
+					(unsigned long)region_info.size >> 20, *pgsize >> 20);
+
+			do_race(device, &region_info, *pgsize);
+			break;
+		}
+
+		if (region == VFIO_PCI_ROM_REGION_INDEX) {
+			printf("No BAR found for %ldMB test\n", *pgsize >> 20);
+			return -ENODEV;
+		}
+	}
+
+	printf("Check dmesg, if there are any VM_FAULT_OOM messages, the test has failed\n");
+
+	return 0;
+}


### PR DESCRIPTION
Add a test to exercise https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c1d9dac0db168198b6f63f460665256dedad9b6e

Revise Makefile, generation assisted by AI, as noted in commit log.

Use MAP_FIXED and madvise in aligning mmaps.

Signed-off-by: Alex Williamson <alex.williamson@redhat.com>